### PR TITLE
Fix panic on nested non-ptr slice or map

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -446,7 +446,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		outt := out.Type()
 		outk := out.Kind()
 		switch outk {
-		case reflect.Interface, reflect.Ptr:
+		case reflect.Interface, reflect.Ptr, reflect.Map:
 			if out.IsNil() {
 				//not predefined type.
 				d.readDocTo(out)
@@ -455,7 +455,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 				d.readDocTo(reflect.ValueOf(out.Interface()))
 			}
 			return true
-		case reflect.Struct, reflect.Map:
+		case reflect.Struct:
 			//read to predefined type.
 			d.readDocTo(reflect.ValueOf(out.Interface()))
 			return true

--- a/decode.go
+++ b/decode.go
@@ -446,7 +446,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		outt := out.Type()
 		outk := out.Kind()
 		switch outk {
-		case reflect.Interface, reflect.Ptr, reflect.Struct, reflect.Map:
+		case reflect.Interface, reflect.Ptr:
 			if out.IsNil() {
 				//not predefined type.
 				d.readDocTo(out)
@@ -454,6 +454,10 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 				//read to predefined type.
 				d.readDocTo(reflect.ValueOf(out.Interface()))
 			}
+			return true
+		case reflect.Struct, reflect.Map:
+			//read to predefined type.
+			d.readDocTo(reflect.ValueOf(out.Interface()))
 			return true
 		}
 		if setterStyle(outt) != setterNone {


### PR DESCRIPTION
This PR solves two issues with `bson.Unmarshal()` that result in a panic 

```
reflect: call of reflect.Value.IsNil on struct Value
```

Issue 1: A BSON document contains an embedded document `\x03` (a struct) but the model into which unmarshaling happens does not contain any tag for this `e_name`. In this case the BSON decoder generates an empty struct type `struct {}` which leads to the panic since its not a pointer or interface type.

Issue 2: A BSON document contains an embedded document `\x03` (a struct) and the model contains a struct (or map) reference instead of a pointer.

```
type A struct {
   X int `bson:"x"`
}

// panics
type B struct {
    Z  A  `bson:"name"`
}

// works
type B struct  {
    Z  *A  `bson:"name"`
}
```